### PR TITLE
Downgrade mpv

### DIFF
--- a/cn.xfangfang.wiliwili.yaml
+++ b/cn.xfangfang.wiliwili.yaml
@@ -72,8 +72,8 @@ modules:
           - PREFIX=/app
         sources:
           - type: archive
-            url: https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n12.2.72.0.tar.gz
-            sha256: dbeaec433d93b850714760282f1d0992b1254fc3b5a6cb7d76fc1340a1e47563
+            url: https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n12.1.14.0.tar.gz
+            sha256: 2fefaa227d2a3b4170797796425a59d1dd2ed5fd231db9b4244468ba327acd0b
             x-checker-data:
               type: anitya
               project-id: 223796
@@ -117,8 +117,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/haasn/libplacebo.git
-            commit: 64c1954570f1cd57f8570a57e51fb0249b57bb90
-            tag: v6.338.2
+            commit: 2805a0d01c029084ab36bf5d0e3c8742012a0b27
+            tag: v6.338.1
             x-checker-data:
               type: git
               tag-pattern: ^v([\d.]+)$
@@ -152,8 +152,8 @@ modules:
             url: https://github.com/FFmpeg/FFmpeg.git
             mirror-urls:
               - https://git.ffmpeg.org/ffmpeg.git
-            commit: 083443d67cb159ce469e5d902346b8d0c2cd1c93
-            tag: n7.0
+            commit: e38092ef9395d7049f871ef4d5411eb410e283e0
+            tag: n6.1.1
             x-checker-data:
               type: git
               tag-pattern: ^n([\d.]{3,7})$

--- a/cn.xfangfang.wiliwili.yaml
+++ b/cn.xfangfang.wiliwili.yaml
@@ -43,8 +43,8 @@ modules:
       - -Dmanpage-build=disabled
     sources:
       - type: archive
-        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.38.0.tar.gz
-        sha256: 86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066
+        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.37.0.tar.gz
+        sha256: 1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf
         x-checker-data:
           type: anitya
           project-id: 5348


### PR DESCRIPTION
On SteamDeck, it seems that even playing 360P videos will cause lag, this PR is just to test if there are similar issues with an older version of mpv.